### PR TITLE
Do not pass FloatingLabelTextInput props to RNs TextInput

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,32 +102,29 @@ class FloatingLabelTextInput extends PureComponent<Props, State> {
       inputRange: [0, this.state.labelHeight],
       outputRange: [1, 0],
     })
+    const { containerStyle, label, labelStyle, ...rest } = this.props
 
     return (
-      <View style={this.props.containerStyle}>
+      <View style={containerStyle}>
         <View style={styles.wrapper}>
           <Animated.Text
             onLayout={this.onLabelContainerLayout}
             style={[
               styles.labelContainer,
-              this.props.labelStyle,
+              labelStyle,
               {
                 marginTop: this.state.labelMarginTop,
                 opacity: labelContainerOpacity,
               },
             ]}>
-            {this.props.label || this.props.placeholder}
+            {label || this.props.placeholder}
           </Animated.Text>
           <Animated.View
             style={[
               styles.textInputContainer,
               { paddingTop: this.state.textInputContainerPaddingTop },
             ]}>
-            <TextInput
-              {...this.props}
-              style={[this.props.style, styles.input]}
-              underlineColorAndroid={this.props.underlineColorAndroid}
-            />
+            <TextInput {...rest} style={[this.props.style, styles.input]} />
           </Animated.View>
         </View>
       </View>


### PR DESCRIPTION
Caught this when using this package in a project where we use `flow`

`containerStyle | label | labelStyle` are not part of the TextInput [props](https://facebook.github.io/react-native/docs/textinput#props) which flow complains about

```
yarn run v1.12.3
$ flow --show-all-errors --quiet
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/@rise-digital/react-native-floating-label-text-input/src/index.js:125:14

Cannot create TextInput element because:
 • property containerStyle is missing in object type [1] but exists in props [2].
 • property label is missing in object type [1] but exists in props [2].
 • property labelStyle is missing in object type [1] but exists in props [2].

     node_modules/@rise-digital/react-native-floating-label-text-input/src/index.js
      122│               styles.textInputContainer,
      123│               { paddingTop: this.state.textInputContainerPaddingTop },
      124│             ]}>
 [2]  125│             <TextInput
      126│               {...this.props}
      127│               style={[this.props.style, styles.input]}
      128│             />
      129│           </Animated.View>
      130│         </View>
      131│       </View>

     node_modules/react-native/Libraries/Components/TextInput/TextInput.js
 [1] 1202│ class InternalTextInputType extends ReactNative.NativeComponent<Props> {
```